### PR TITLE
Check for `defaultLibrary` even when symbols don't have a `valueDeclaration`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,10 @@ export = function init(modules: { typescript: typeof import("typescript/lib/tsse
 							if (program.isSourceFileDefaultLibrary(decl.getSourceFile())) {
 								modifierSet |= 1 << TokenModifier.defaultLibrary;
 							}
+						} else if (symbol.declarations && symbol.declarations.length > 0) {
+							if (program.isSourceFileDefaultLibrary(symbol.declarations[0].getSourceFile())) {
+								modifierSet |= 1 << TokenModifier.defaultLibrary;
+							}
 						}
 
 						collector(node, typeIdx, modifierSet);

--- a/src/test/semanticTokens.test.ts
+++ b/src/test/semanticTokens.test.ts
@@ -473,7 +473,7 @@ suite('HTML Semantic Tokens', () => {
         ]);
     });
 
-    test.only('Library without value declaration', () => {
+    test('Library without value declaration', () => {
         const input = [
             /*0*/'type MyIterator = IterableIterator<{ name: string }>;',
         ].join('\n');

--- a/src/test/semanticTokens.test.ts
+++ b/src/test/semanticTokens.test.ts
@@ -473,6 +473,15 @@ suite('HTML Semantic Tokens', () => {
         ]);
     });
 
+    test.only('Library without value declaration', () => {
+        const input = [
+            /*0*/'type MyIterator = IterableIterator<{ name: string }>;',
+        ].join('\n');
+        assertTokens('main.ts', { 'main.ts': input }, [
+            t(0, 5, 10, 'type.declaration'), t(0, 18, 16, 'interface.defaultLibrary'), t(0, 37, 4, 'property.declaration'),
+        ]);
+    })
+
     test('JSX', () => {
         const input = [
             /*0*/'import * as React from "react";',


### PR DESCRIPTION
Fixes #7

The problem is that the `defaultLibrary` modifier currently only gets added to symbols which have a `valueDeclaration`, so this addresses that.